### PR TITLE
mod管理器内mod设置入口显示判定条件改善

### DIFF
--- a/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml.cs
+++ b/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml.cs
@@ -18,6 +18,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using VPet_Simulator.Core;
+using VPet_Simulator.Windows.Interface;
 
 namespace VPet_Simulator.Windows
 {
@@ -339,11 +340,16 @@ namespace VPet_Simulator.Windows
 
             foreach (var mainplug in mw.Plugins)
             {
-                if (mainplug.PluginName == mod.Name)
+                try
                 {
-                    ButtonSetting.Visibility = Visibility.Visible;
-                    return;
+                    if (mainplug.GetType().GetMethod("Setting").DeclaringType != typeof(MainPlugin)
+                    && mainplug.GetType().Assembly.Location.Contains(mod.Path.FullName))
+                    {
+                        ButtonSetting.Visibility = Visibility.Visible;
+                        return;
+                    }
                 }
+                finally { }
             }
             ButtonSetting.Visibility = Visibility.Collapsed;
         }
@@ -915,11 +921,16 @@ namespace VPet_Simulator.Windows
         {
             foreach (var mainplug in mw.Plugins)
             {
-                if (mainplug.PluginName == mod.Name)
+                try
                 {
-                    mainplug.Setting();
-                    return;
+                    if (mainplug.GetType().GetMethod("Setting").DeclaringType != typeof(MainPlugin)
+                    && mainplug.GetType().Assembly.Location.Contains(mod.Path.FullName))
+                    {
+                        mainplug.Setting();
+                        return;
+                    }
                 }
+                finally { }
             }
         }
 


### PR DESCRIPTION
将条件由判定lps文件内mod名字与mod代码内PluginName属性是否一致
更改为MainPlugin.Setting()是否被重写，以及目前遍历到的mod路径与目标mod的路径是否一致