### PR TITLE
修复屏幕边界计算+缓存屏幕外包矩形

### DIFF
--- a/VPet-Simulator.Windows/Function/MWController.cs
+++ b/VPet-Simulator.Windows/Function/MWController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows.Forms;
 using System.Windows.Interop;
+using System.Drawing;
 using VPet_Simulator.Core;
 
 namespace VPet_Simulator.Windows
@@ -15,36 +16,43 @@ namespace VPet_Simulator.Windows
             this.mw = mw;
         }
 
+        private Rectangle? _screenBorder = null;
+        private Rectangle ScreenBorder
+        {
+            get
+            {
+                if (_screenBorder == null)
+                {
+                    var windowInteropHelper = new WindowInteropHelper(mw);
+                    var currentScreen = Screen.FromHandle(windowInteropHelper.Handle);
+                    _screenBorder = currentScreen.Bounds;
+                }
+                return (Rectangle)_screenBorder;
+            }
+        }
+        public void ClearScreenBorderCache()
+        {
+            _screenBorder = null;
+        }
+
         public double GetWindowsDistanceLeft()
         {
-            return mw.Dispatcher.Invoke(() => mw.Left);
+            return mw.Dispatcher.Invoke(() => mw.Left - ScreenBorder.X);
         }
 
         public double GetWindowsDistanceUp()
         {
-            return mw.Dispatcher.Invoke(() => mw.Top);
+            return mw.Dispatcher.Invoke(() => mw.Top - ScreenBorder.Y);
         }
 
         public double GetWindowsDistanceRight()
         {
-            return mw.Dispatcher.Invoke(() =>
-            {
-                var windowInteropHelper = new WindowInteropHelper(mw);
-                var currentScreen = Screen.FromHandle(windowInteropHelper.Handle);
-                var currentScreenBorder = currentScreen.Bounds;
-                return currentScreenBorder.Width - mw.Left - mw.Width;
-            });
+            return mw.Dispatcher.Invoke(() => ScreenBorder.Width + ScreenBorder.X - mw.Left - mw.Width);
         }
 
         public double GetWindowsDistanceDown()
         {
-            return mw.Dispatcher.Invoke(() =>
-            {
-                var windowInteropHelper = new WindowInteropHelper(mw);
-                var currentScreen = Screen.FromHandle(windowInteropHelper.Handle);
-                var currentScreenBorder = currentScreen.Bounds;
-                return currentScreenBorder.Height - mw.Top - mw.Height;
-            });
+            return mw.Dispatcher.Invoke(() => ScreenBorder.Height + ScreenBorder.Y - mw.Top - mw.Height);
         }
 
         public void MoveWindows(double X, double Y)
@@ -53,6 +61,7 @@ namespace VPet_Simulator.Windows
             {
                 mw.Left += X * ZoomRatio;
                 mw.Top += Y * ZoomRatio;
+                ClearScreenBorderCache();
             });
         }
 

--- a/VPet-Simulator.Windows/MainWindow.xaml.cs
+++ b/VPet-Simulator.Windows/MainWindow.xaml.cs
@@ -614,6 +614,7 @@ namespace VPet_Simulator.Windows
                     Main.DisplayToNomal();
                     Left = (SystemParameters.PrimaryScreenWidth - Width) / 2;
                     Top = (SystemParameters.PrimaryScreenHeight - Height) / 2;
+                    (Core.Controller as MWController).ClearScreenBorderCache();
                 }));
                 m_menu.MenuItems.Add(new MenuItem("反馈中心".Translate(), (x, y) => { new winReport(this).Show(); }));
                 m_menu.MenuItems.Add(new MenuItem("开发控制台".Translate(), (x, y) => { new winConsole(this).Show(); }));


### PR DESCRIPTION
已测试乱走+拖动+重置状态，可正常在所处屏边缘爬行
各屏内静止状态读数如下图（右侧的横屏是主显示器）
![image](https://github.com/LorisYounger/VPet/assets/34098703/52f0f670-799c-41fd-846c-01379cb582d2)
![image](https://github.com/LorisYounger/VPet/assets/34098703/9aee0c67-4353-4164-a0ba-19a2658d889b)
