### PR TITLE
屏幕距离测算兼容模式

### DIFF
--- a/VPet-Simulator.Windows/Function/MWController.cs
+++ b/VPet-Simulator.Windows/Function/MWController.cs
@@ -1,4 +1,7 @@
-﻿using VPet_Simulator.Core;
+﻿using System.Windows.Forms;
+using System.Windows.Interop;
+using System.Drawing;
+using VPet_Simulator.Core;
 
 namespace VPet_Simulator.Windows
 {
@@ -13,24 +16,43 @@ namespace VPet_Simulator.Windows
             this.mw = mw;
         }
 
-        public double GetWindowsDistanceDown()
+        private Rectangle? _screenBorder = null;
+        private Rectangle ScreenBorder
         {
-            return mw.Dispatcher.Invoke(() => System.Windows.SystemParameters.PrimaryScreenHeight - mw.Top - mw.Height);
+            get
+            {
+                if (_screenBorder == null)
+                {
+                    var windowInteropHelper = new WindowInteropHelper(mw);
+                    var currentScreen = Screen.FromHandle(windowInteropHelper.Handle);
+                    _screenBorder = currentScreen.Bounds;
+                }
+                return (Rectangle)_screenBorder;
+            }
+        }
+        public void ClearScreenBorderCache()
+        {
+            _screenBorder = null;
         }
 
         public double GetWindowsDistanceLeft()
         {
-            return mw.Dispatcher.Invoke(() => mw.Left);
-        }
-
-        public double GetWindowsDistanceRight()
-        {
-            return mw.Dispatcher.Invoke(() => System.Windows.SystemParameters.PrimaryScreenWidth - mw.Left - mw.Width);
+            return mw.Dispatcher.Invoke(() => mw.Left - ScreenBorder.X);
         }
 
         public double GetWindowsDistanceUp()
         {
-            return mw.Dispatcher.Invoke(() => mw.Top);
+            return mw.Dispatcher.Invoke(() => mw.Top - ScreenBorder.Y);
+        }
+
+        public double GetWindowsDistanceRight()
+        {
+            return mw.Dispatcher.Invoke(() => ScreenBorder.Width + ScreenBorder.X - mw.Left - mw.Width);
+        }
+
+        public double GetWindowsDistanceDown()
+        {
+            return mw.Dispatcher.Invoke(() => ScreenBorder.Height + ScreenBorder.Y - mw.Top - mw.Height);
         }
 
         public void MoveWindows(double X, double Y)
@@ -39,6 +61,7 @@ namespace VPet_Simulator.Windows
             {
                 mw.Left += X * ZoomRatio;
                 mw.Top += Y * ZoomRatio;
+                ClearScreenBorderCache();
             });
         }
 

--- a/VPet-Simulator.Windows/MainWindow.xaml.cs
+++ b/VPet-Simulator.Windows/MainWindow.xaml.cs
@@ -655,7 +655,7 @@ namespace VPet_Simulator.Windows
                     Main.DisplayToNomal();
                     Left = (SystemParameters.PrimaryScreenWidth - Width) / 2;
                     Top = (SystemParameters.PrimaryScreenHeight - Height) / 2;
-                    //(Core.Controller as MWController).ClearScreenBorderCache();
+                    (Core.Controller as MWController).ClearScreenBorderCache();
                 }));
                 m_menu.MenuItems.Add(new MenuItem("反馈中心".Translate(), (x, y) => { new winReport(this).Show(); }));
                 m_menu.MenuItems.Add(new MenuItem("开发控制台".Translate(), (x, y) => { new winConsole(this).Show(); }));


### PR DESCRIPTION
 fix #152 
------

1. 单屏100%缩放测试
![test_100%](https://github.com/LorisYounger/VPet/assets/34098703/b97e18f9-f8a7-42ab-8756-5cf6bfb5da27)
1. 单屏150%缩放测试
![test_150%](https://github.com/LorisYounger/VPet/assets/34098703/35cf5259-5c2a-463a-8d62-0084955f9c56)
1. 多屏，主屏150%缩放测试
<img width="1500" alt="test_multi_150%" src="https://github.com/LorisYounger/VPet/assets/34098703/3af73907-beee-44eb-a578-8d5fce65737a">
1. 多屏且副屏150%缩放，主屏125%缩放测试  
![test_150_125](https://github.com/LorisYounger/VPet/assets/34098703/430f3a98-fd42-42f5-9642-d30baaefc4bd)

------

TODO：各种自求多福模式
1. 主屏高缩放，桌宠位于副屏
    ![image](https://github.com/LorisYounger/VPet/assets/34098703/7e8c5fc5-456d-492d-9ecd-36ad913bb87e)
    主屏`1920*1080 125%`；副屏右侧中线对齐`1080*1920 100%`，主屏长宽为实际像素值，副屏定位框的全部参数被反向缩放了1.25倍
1. 桌宠位于高缩放的副屏
    ![image](https://github.com/LorisYounger/VPet/assets/34098703/45f1acfa-f73d-44d4-a367-776c4a64de73)
    主屏`1920*1080 125%`；副屏下居中对齐`1080*1920 150%`，这回xy坐标是按主屏像素的，但是长宽被缩放了`150%/125%=1.2`倍
1. 初步实验结果：Dpi接口跟主屏走，副屏长宽会随相对缩放大小而缩放；高缩放下位置正确，但100%缩放下位置会有偏差
1. 布响丸辣