### PR TITLE
可配置桌宠移动区域

### DIFF
--- a/VPet-Simulator.Windows.Interface/Setting.cs
+++ b/VPet-Simulator.Windows.Interface/Setting.cs
@@ -430,5 +430,44 @@ namespace VPet_Simulator.Windows.Interface
                 this["gameconfig"].SetBool("autobuy", value);
             }
         }
+
+        public bool MoveAreaDefault
+        {
+            get
+            {
+                var line = FindLine("movearea");
+                if (line == null)
+                    return true;
+                return line.GetBool("set");
+            }
+            set
+            {
+                var line = FindorAddLine("movearea");
+                line.SetBool("set", value);
+            }
+        }
+        public System.Drawing.Rectangle MoveArea
+        {
+            get
+            {
+                var line = FindLine("movearea");
+                if (line == null)
+                    return default(System.Drawing.Rectangle);
+                return new System.Drawing.Rectangle(
+                    line.GetInt("x", 0),
+                    line.GetInt("y", 0),
+                    line.GetInt("w", 114),
+                    line.GetInt("h", 514)
+                );
+            }
+            set
+            {
+                var line = FindorAddLine("movearea");
+                line.SetInt("x", value.X);
+                line.SetInt("y", value.Y);
+                line.SetInt("w", value.Width);
+                line.SetInt("h", value.Height);
+            }
+        }
     }
 }

--- a/VPet-Simulator.Windows/Function/MWController.cs
+++ b/VPet-Simulator.Windows/Function/MWController.cs
@@ -14,18 +14,25 @@ namespace VPet_Simulator.Windows
         public MWController(MainWindow mw)
         {
             this.mw = mw;
+            _isPrimaryScreen = mw.Set.MoveAreaDefault;
+            _screenBorder = mw.Set.MoveArea;
         }
 
-        private static Rectangle _screenBorder;
-        private static bool _isPrimaryScreen = true;
-        public static bool IsPrimaryScreen
+        private Rectangle _screenBorder;
+        private bool _isPrimaryScreen = true;
+        public bool IsPrimaryScreen
         {
             get
             {
                 return _isPrimaryScreen;
             }
+            private set
+            {
+                _isPrimaryScreen = value;
+                mw.Set.MoveAreaDefault = value;
+            }
         }
-        public static Rectangle ScreenBorder
+        public Rectangle ScreenBorder
         {
             get
             {
@@ -34,12 +41,13 @@ namespace VPet_Simulator.Windows
             set
             {
                 _screenBorder = value;
-                _isPrimaryScreen = false;
+                mw.Set.MoveArea = value;
+                IsPrimaryScreen = false;
             }
         }
-        public static void ResetScreenBorder()
+        public void ResetScreenBorder()
         {
-            _isPrimaryScreen = true;
+            IsPrimaryScreen = true;
         }
 
         public double GetWindowsDistanceLeft()

--- a/VPet-Simulator.Windows/Function/MWController.cs
+++ b/VPet-Simulator.Windows/Function/MWController.cs
@@ -16,38 +16,30 @@ namespace VPet_Simulator.Windows
             this.mw = mw;
         }
 
-        private bool _screenDetected = false;
-        private Rectangle _screenBorder;
-        private bool _isPrimaryScreen = true;
-        public bool IsPrimaryScreen
+        private static Rectangle _screenBorder;
+        private static bool _isPrimaryScreen = true;
+        public static bool IsPrimaryScreen
         {
             get
             {
-                if(!_screenDetected) DetectCurrentScreen();
                 return _isPrimaryScreen;
             }
         }
-        public Rectangle ScreenBorder
+        public static Rectangle ScreenBorder
         {
             get
             {
-                if (!_screenDetected) DetectCurrentScreen();
                 return _screenBorder;
             }
+            set
+            {
+                _screenBorder = value;
+                _isPrimaryScreen = false;
+            }
         }
-        private void DetectCurrentScreen()
+        public static void ResetScreenBorder()
         {
-            var windowInteropHelper = new WindowInteropHelper(mw);
-            var currentScreen = Screen.FromHandle(windowInteropHelper.Handle);
-            // TODO 多屏+非100%缩放下以上API跟Left、Top一样都是错的
-
-            _isPrimaryScreen = currentScreen.Primary;
-            _screenBorder = currentScreen.Bounds;
-            _screenDetected = true;
-        }
-        public void ClearScreenBorderCache()
-        {
-            _screenDetected = false;
+            _isPrimaryScreen = true;
         }
 
         public double GetWindowsDistanceLeft()
@@ -92,7 +84,6 @@ namespace VPet_Simulator.Windows
             {
                 mw.Left += X * ZoomRatio;
                 mw.Top += Y * ZoomRatio;
-                ClearScreenBorderCache();
             });
         }
 

--- a/VPet-Simulator.Windows/Function/MWController.cs
+++ b/VPet-Simulator.Windows/Function/MWController.cs
@@ -1,4 +1,7 @@
-﻿using VPet_Simulator.Core;
+﻿using System.Windows.Forms;
+using System.Windows.Interop;
+using System.Drawing;
+using VPet_Simulator.Core;
 
 namespace VPet_Simulator.Windows
 {
@@ -13,24 +16,43 @@ namespace VPet_Simulator.Windows
             this.mw = mw;
         }
 
-        public double GetWindowsDistanceDown()
+        private Rectangle? _screenBorder = null;
+        private Rectangle ScreenBorder
         {
-            return mw.Dispatcher.Invoke(() => System.Windows.SystemParameters.PrimaryScreenHeight - mw.Top - mw.Height);
+            get
+            {
+                if (_screenBorder == null)
+                {
+                    var windowInteropHelper = new WindowInteropHelper(mw);
+                    var currentScreen = Screen.FromHandle(windowInteropHelper.Handle);
+                    _screenBorder = currentScreen.Bounds;
+                }
+                return (Rectangle)_screenBorder;
+            }
+        }
+        public void ClearScreenBorderCache()
+        {
+            _screenBorder = null;
         }
 
         public double GetWindowsDistanceLeft()
         {
-            return mw.Dispatcher.Invoke(() => mw.Left);
-        }
-
-        public double GetWindowsDistanceRight()
-        {
-            return mw.Dispatcher.Invoke(() => System.Windows.SystemParameters.PrimaryScreenWidth - mw.Left - mw.Width);
+            return mw.Dispatcher.Invoke(() => mw.Left - ScreenBorder.X);
         }
 
         public double GetWindowsDistanceUp()
         {
-            return mw.Dispatcher.Invoke(() => mw.Top);
+            return mw.Dispatcher.Invoke(() => mw.Top - ScreenBorder.Y);
+        }
+
+        public double GetWindowsDistanceRight()
+        {
+            return mw.Dispatcher.Invoke(() => ScreenBorder.Width + ScreenBorder.X - mw.Left - mw.Width);
+        }
+
+        public double GetWindowsDistanceDown()
+        {
+            return mw.Dispatcher.Invoke(() => ScreenBorder.Height + ScreenBorder.Y - mw.Top - mw.Height);
         }
 
         public void MoveWindows(double X, double Y)
@@ -39,6 +61,7 @@ namespace VPet_Simulator.Windows
             {
                 mw.Left += X * ZoomRatio;
                 mw.Top += Y * ZoomRatio;
+                ClearScreenBorderCache();
             });
         }
 

--- a/VPet-Simulator.Windows/MainWindow.xaml.cs
+++ b/VPet-Simulator.Windows/MainWindow.xaml.cs
@@ -655,7 +655,7 @@ namespace VPet_Simulator.Windows
                     Main.DisplayToNomal();
                     Left = (SystemParameters.PrimaryScreenWidth - Width) / 2;
                     Top = (SystemParameters.PrimaryScreenHeight - Height) / 2;
-                    //(Core.Controller as MWController).ClearScreenBorderCache();
+                    (Core.Controller as MWController).ClearScreenBorderCache();
                 }));
                 m_menu.MenuItems.Add(new MenuItem("反馈中心".Translate(), (x, y) => { new winReport(this).Show(); }));
                 m_menu.MenuItems.Add(new MenuItem("开发控制台".Translate(), (x, y) => { new winConsole(this).Show(); }));

--- a/VPet-Simulator.Windows/MainWindow.xaml.cs
+++ b/VPet-Simulator.Windows/MainWindow.xaml.cs
@@ -655,7 +655,6 @@ namespace VPet_Simulator.Windows
                     Main.DisplayToNomal();
                     Left = (SystemParameters.PrimaryScreenWidth - Width) / 2;
                     Top = (SystemParameters.PrimaryScreenHeight - Height) / 2;
-                    (Core.Controller as MWController).ClearScreenBorderCache();
                 }));
                 m_menu.MenuItems.Add(new MenuItem("反馈中心".Translate(), (x, y) => { new winReport(this).Show(); }));
                 m_menu.MenuItems.Add(new MenuItem("开发控制台".Translate(), (x, y) => { new winConsole(this).Show(); }));

--- a/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml
+++ b/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml
@@ -523,7 +523,7 @@
                                     <RowDefinition Height="35" />
                                     <RowDefinition Height="35" />
                                 </Grid.RowDefinitions>
-                                <TextBlock Grid.Row="0" Text="{ll:Str '当前区域：'}"/>
+                                <TextBlock Grid.Row="0" Text="{ll:Str '当前移动区域：'}"/>
                                 <TextBlock x:Name="textMoveArea" Grid.Column="1" Grid.ColumnSpan="2" Text="{ll:Str '主屏幕'}"/>
                                 <Button x:Name="BtnSetMoveArea_Default" Grid.Row="1" Grid.Column="0" Margin="5,5,5,5" Padding="1"
                                     pu:ButtonHelper.CornerRadius="4" Background="{DynamicResource SecondaryLight}"

--- a/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml
+++ b/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml
@@ -397,6 +397,8 @@
                                 <RowDefinition Height="35" />
                                 <RowDefinition Height="35" />
                                 <RowDefinition Height="35" />
+                                <RowDefinition Height="35" />
+                                <RowDefinition Height="35" />
                             </Grid.RowDefinitions>
                             <pu:Switch x:Name="CalFunctionBox" Grid.Column="2" Background="Transparent"
                                     BorderBrush="{DynamicResource PrimaryDark}" BoxHeight="18" BoxWidth="35"
@@ -424,7 +426,7 @@
                                     <ComboBoxItem Content="Ill" />
                                 </ComboBox>
                             </Grid>
-                            <Grid Grid.Row="5" Grid.RowSpan="2" Grid.Column="2">
+                            <Grid Grid.Row="5" Grid.RowSpan="4" Grid.Column="2">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="*" />
@@ -511,7 +513,37 @@
                                     </ComboBoxItem>
                                 </ComboBox>
                             </Grid>
-
+                            <Grid Grid.Row="7" Grid.RowSpan="2" Grid.Column="3">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="35" />
+                                    <RowDefinition Height="35" />
+                                </Grid.RowDefinitions>
+                                <TextBlock Grid.Row="0" Text="{ll:Str '当前区域：'}"/>
+                                <TextBlock Grid.Column="1" Grid.ColumnSpan="2" Text="{ll:Str '主屏幕'}"/>
+                                <Button x:Name="BtnSetScreen_Default" Grid.Row="1" Grid.Column="0" Margin="5,5,5,5" Padding="1"
+                                    pu:ButtonHelper.CornerRadius="4" Background="{DynamicResource SecondaryLight}"
+                                    Click="BtnSetScreen_Default_Click" Content="{ll:Str 重置为主屏}"/>
+                                <Button x:Name="BtnSetScreen_DetectScreen" Grid.Row="1" Grid.Column="1" Margin="5,5,5,5" Padding="1"
+                                    pu:ButtonHelper.CornerRadius="4" Background="{DynamicResource SecondaryLight}"
+                                    Click="BtnSetScreen_DetectScreen_Click" Content="{ll:Str 设为桌宠屏幕}"
+                                    ToolTip="{ll:Str 当屏幕分辨率不为100%时可能识别有误}"/>
+                                <Button x:Name="BtnSetScreen_Window" Grid.Row="1" Grid.Column="2" Margin="5,5,5,5" Padding="1"
+                                    pu:ButtonHelper.CornerRadius="4" Background="{DynamicResource SecondaryLight}"
+                                    Click="BtnSetScreen_Window_Click" Content="{ll:Str 设为窗口范围}">
+                                    <Button.ToolTip>
+                                        <TextBlock>
+                                            <TextBlock Text="{ll:Str 使用设置窗口框选范围后点击}"/>
+                                            <LineBreak /> 
+                                            <TextBlock Text="{ll:Str 注：双击顶端可最大化设置页}"/>
+                                        </TextBlock>
+                                    </Button.ToolTip>
+                                </Button>
+                            </Grid>
                             <TextBlock Grid.Row="0" VerticalAlignment="Center" Text="{ll:Str 数据计算}" />
                             <TextBlock Grid.Row="1" VerticalAlignment="Center" Text="{ll:Str 显示状态}" />
                             <TextBlock Grid.Row="5" VerticalAlignment="Center" Text="{ll:Str 桌宠移动}" />

--- a/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml
+++ b/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml
@@ -524,17 +524,17 @@
                                     <RowDefinition Height="35" />
                                 </Grid.RowDefinitions>
                                 <TextBlock Grid.Row="0" Text="{ll:Str '当前区域：'}"/>
-                                <TextBlock Grid.Column="1" Grid.ColumnSpan="2" Text="{ll:Str '主屏幕'}"/>
-                                <Button x:Name="BtnSetScreen_Default" Grid.Row="1" Grid.Column="0" Margin="5,5,5,5" Padding="1"
+                                <TextBlock x:Name="textMoveArea" Grid.Column="1" Grid.ColumnSpan="2" Text="{ll:Str '主屏幕'}"/>
+                                <Button x:Name="BtnSetMoveArea_Default" Grid.Row="1" Grid.Column="0" Margin="5,5,5,5" Padding="1"
                                     pu:ButtonHelper.CornerRadius="4" Background="{DynamicResource SecondaryLight}"
-                                    Click="BtnSetScreen_Default_Click" Content="{ll:Str 重置为主屏}"/>
-                                <Button x:Name="BtnSetScreen_DetectScreen" Grid.Row="1" Grid.Column="1" Margin="5,5,5,5" Padding="1"
+                                    Click="BtnSetMoveArea_Default_Click" Content="{ll:Str 重置为主屏}"/>
+                                <Button x:Name="BtnSetMoveArea_DetectScreen" Grid.Row="1" Grid.Column="1" Margin="5,5,5,5" Padding="1"
                                     pu:ButtonHelper.CornerRadius="4" Background="{DynamicResource SecondaryLight}"
-                                    Click="BtnSetScreen_DetectScreen_Click" Content="{ll:Str 设为桌宠屏幕}"
+                                    Click="BtnSetMoveArea_DetectScreen_Click" Content="{ll:Str 设为桌宠屏幕}"
                                     ToolTip="{ll:Str 当屏幕分辨率不为100%时可能识别有误}"/>
-                                <Button x:Name="BtnSetScreen_Window" Grid.Row="1" Grid.Column="2" Margin="5,5,5,5" Padding="1"
+                                <Button x:Name="BtnSetMoveArea_Window" Grid.Row="1" Grid.Column="2" Margin="5,5,5,5" Padding="1"
                                     pu:ButtonHelper.CornerRadius="4" Background="{DynamicResource SecondaryLight}"
-                                    Click="BtnSetScreen_Window_Click" Content="{ll:Str 设为窗口范围}">
+                                    Click="BtnSetMoveArea_Window_Click" Content="{ll:Str 设为窗口范围}">
                                     <Button.ToolTip>
                                         <TextBlock>
                                             <TextBlock Text="{ll:Str 使用设置窗口框选范围后点击}"/>

--- a/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml.cs
+++ b/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml.cs
@@ -615,6 +615,25 @@ namespace VPet_Simulator.Windows
             }
         }
 
+        private void BtnSetScreen_Default_Click(object sender, RoutedEventArgs e)
+        {
+            MWController.ResetScreenBorder();
+        }
+
+        private void BtnSetScreen_DetectScreen_Click(object sender, RoutedEventArgs e)
+        {
+            var windowInteropHelper = new System.Windows.Interop.WindowInteropHelper(mw);
+            var currentScreen = System.Windows.Forms.Screen.FromHandle(windowInteropHelper.Handle);
+            MWController.ScreenBorder = currentScreen.Bounds;
+        }
+
+        private void BtnSetScreen_Window_Click(object sender, RoutedEventArgs e)
+        {
+            MWController.ScreenBorder = new System.Drawing.Rectangle(
+                (int)Left, (int)Top, 
+                (int)Width, (int)Height
+            );
+        }
 
         private void hyper_moreInfo(object sender, RoutedEventArgs e)
         {

--- a/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml.cs
+++ b/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml.cs
@@ -212,6 +212,8 @@ namespace VPet_Simulator.Windows
             voicetimer.Tick += Voicetimer_Tick;
 
             AllowChange = true;
+
+            UpdateMoveAreaText();
         }
 
         private void Voicetimer_Tick(object sender, EventArgs e)
@@ -615,24 +617,42 @@ namespace VPet_Simulator.Windows
             }
         }
 
-        private void BtnSetScreen_Default_Click(object sender, RoutedEventArgs e)
+        private void UpdateMoveAreaText()
         {
-            MWController.ResetScreenBorder();
+            var mwCtrl = mw.Core.Controller as MWController;
+            if (mwCtrl.IsPrimaryScreen)
+            {
+                textMoveArea.Text = "主屏幕".Translate();
+                return;
+            }
+            var rect = mwCtrl.ScreenBorder;
+            textMoveArea.Text = $"X:{rect.X};Y:{rect.Y};W:{rect.Width};H:{rect.Height}";
         }
 
-        private void BtnSetScreen_DetectScreen_Click(object sender, RoutedEventArgs e)
+        private void BtnSetMoveArea_Default_Click(object sender, RoutedEventArgs e)
+        {
+            var mwCtrl = mw.Core.Controller as MWController;
+            mwCtrl.ResetScreenBorder();
+            UpdateMoveAreaText();
+        }
+
+        private void BtnSetMoveArea_DetectScreen_Click(object sender, RoutedEventArgs e)
         {
             var windowInteropHelper = new System.Windows.Interop.WindowInteropHelper(mw);
             var currentScreen = System.Windows.Forms.Screen.FromHandle(windowInteropHelper.Handle);
-            MWController.ScreenBorder = currentScreen.Bounds;
+            var mwCtrl = mw.Core.Controller as MWController;
+            mwCtrl.ScreenBorder = currentScreen.Bounds;
+            UpdateMoveAreaText();
         }
 
-        private void BtnSetScreen_Window_Click(object sender, RoutedEventArgs e)
+        private void BtnSetMoveArea_Window_Click(object sender, RoutedEventArgs e)
         {
-            MWController.ScreenBorder = new System.Drawing.Rectangle(
+            var mwCtrl = mw.Core.Controller as MWController;
+            mwCtrl.ScreenBorder = new System.Drawing.Rectangle(
                 (int)Left, (int)Top, 
                 (int)Width, (int)Height
             );
+            UpdateMoveAreaText();
         }
 
         private void hyper_moreInfo(object sender, RoutedEventArgs e)

--- a/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml.cs
+++ b/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml.cs
@@ -645,13 +645,31 @@ namespace VPet_Simulator.Windows
             UpdateMoveAreaText();
         }
 
+        private static System.Reflection.FieldInfo leftGetter, topGetter;
         private void BtnSetMoveArea_Window_Click(object sender, RoutedEventArgs e)
         {
             var mwCtrl = mw.Core.Controller as MWController;
-            mwCtrl.ScreenBorder = new System.Drawing.Rectangle(
-                (int)Left, (int)Top, 
-                (int)Width, (int)Height
-            );
+            System.Drawing.Rectangle bounds;
+            if (WindowState == WindowState.Maximized)
+            {
+                // 反射捞一下左上角
+                if (leftGetter == null) leftGetter = typeof(Window).GetField("_actualLeft", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                if (topGetter == null) topGetter = typeof(Window).GetField("_actualTop", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var actualLeft = Convert.ToInt32(leftGetter.GetValue(this)); 
+                var actualTop = Convert.ToInt32(topGetter.GetValue(this));
+                bounds = new System.Drawing.Rectangle(
+                    actualLeft, actualTop,
+                    (int)ActualWidth, (int)ActualHeight
+                );
+            }
+            else
+            {
+                bounds = new System.Drawing.Rectangle(
+                    (int)Left, (int)Top,
+                    (int)Width, (int)Height
+                );
+            }
+            mwCtrl.ScreenBorder = bounds;
             UpdateMoveAreaText();
         }
 


### PR DESCRIPTION
![移动区域设置](https://github.com/LorisYounger/VPet/assets/34098703/c9474f35-1527-4bc2-bffd-bde2d939d8d3)
对多屏API忍无可忍，那就自己做设置罢
三个按钮分别可选中：
* 上个版本的活动区域（主屏矩形）
* https://github.com/LorisYounger/VPet/pull/137 框选的区域（桌宠所在屏幕，不支持DPI缩放，自求多福）
* 以及……所见所得，设置窗口自己覆盖的矩形区域

------
这边跟[隔壁PR](https://github.com/LorisYounger/VPet/pull/164)是互斥的，所以那边摆了吧