### PR TITLE
feat(*): Hide vpet window from task switcher

### DIFF
--- a/VPet-Simulator.Windows.Interface/Setting.cs
+++ b/VPet-Simulator.Windows.Interface/Setting.cs
@@ -444,6 +444,14 @@ namespace VPet_Simulator.Windows.Interface
                 this["gameconfig"].SetBool("autogift", value);
             }
         }
+        /// <summary>
+        /// 在任务切换器(Alt+Tab)中隐藏窗口
+        /// </summary>
+        public bool HideFromTaskControl
+        {
+            get => this["gameconfig"].GetBool("hide_from_task_control");
+            set => this["gameconfig"].SetBool("hide_from_task_control", value);
+        }
 
         public bool MoveAreaDefault
         {

--- a/VPet-Simulator.Windows/MainWindow.xaml.cs
+++ b/VPet-Simulator.Windows/MainWindow.xaml.cs
@@ -847,6 +847,13 @@ namespace VPet_Simulator.Windows
                 {
                     var styleStruct = (STYLESTRUCT)Marshal.PtrToStructure(lParam, typeof(STYLESTRUCT));
                     styleStruct.styleNew |= (int)Win32.ExtendedWindowStyles.WS_EX_LAYERED;
+
+                    // Hide windows from alt+tab: https://stackoverflow.com/questions/357076/best-way-to-hide-a-window-from-the-alt-tab-program-switcher
+                    if (Set.HideFromTaskControl)
+                    {
+                        styleStruct.styleNew |= (int)Win32.ExtendedWindowStyles.WS_EX_TOOLWINDOW;
+                    }
+
                     Marshal.StructureToPtr(styleStruct, lParam, false);
                     handled = true;
                 }

--- a/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml
+++ b/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml
@@ -7,7 +7,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:pu="clr-namespace:Panuon.WPF.UI;assembly=Panuon.WPF.UI"
         xmlns:system="clr-namespace:System;assembly=mscorlib" Title="{ll:Str 设置}"
-        Width="{ll:Dbe SettingWidth, DefValue=500}" Height="550" Closing="WindowX_Closing" FontSize="16"
+        Width="{ll:Dbe SettingWidth, DefValue=500}" Height="650" Closing="WindowX_Closing" FontSize="16"
         Style="{DynamicResource BaseWindowXStyle}" Topmost="True" WindowStartupLocation="CenterScreen" mc:Ignorable="d">
     <!--<pu:WindowX.Resources>
         <DataTemplate x:Key="DIYDataTemplate">
@@ -41,6 +41,7 @@
                                 <ColumnDefinition />
                             </Grid.ColumnDefinitions>
                             <Grid.RowDefinitions>
+                                <RowDefinition Height="35" />
                                 <RowDefinition Height="35" />
                                 <RowDefinition Height="35" />
                                 <RowDefinition Height="35" />
@@ -214,6 +215,14 @@
                             <ComboBox x:Name="PetBox" Grid.Row="11" Grid.Column="2" Margin="0,3,0,2" FontSize="16"
                                     SelectionChanged="PetBox_SelectionChanged"
                                     Style="{DynamicResource StandardComboBoxStyle}" ToolTip="{ll:Str '加载的宠物动画,重启后生效'}" />
+                            <TextBlock Grid.Row="13" VerticalAlignment="Center" Text="{ll:Str 隐藏窗口}" />
+                            <pu:Switch x:Name="SwitchHideFromTaskControl" Grid.Row="13" Grid.Column="2" Background="Transparent"
+                                    BorderBrush="{DynamicResource PrimaryDark}" BoxHeight="18" BoxWidth="35"
+                                    Checked="SwitchHideFromTaskControl_OnChecked" CheckedBackground="{DynamicResource Primary}"
+                                    CheckedBorderBrush="{DynamicResource Primary}"
+                                    CheckedToggleBrush="{DynamicResource DARKPrimaryText}" Content="{ll:Str '在任务切换器中隐藏窗口'}"
+                                    ToggleBrush="{DynamicResource PrimaryDark}" ToggleShadowColor="{x:Null}"
+                                    ToggleSize="14" ToolTip="{ll:Str '在Alt+Tab中隐藏'}" Unchecked="SwitchHideFromTaskControl_OnChecked" />
                         </Grid>
                     </ScrollViewer>
                     <Button x:Name="ButtonRestartGraph" VerticalAlignment="Bottom"

--- a/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml.cs
+++ b/VPet-Simulator.Windows/WinDesign/winGameSetting.xaml.cs
@@ -61,6 +61,7 @@ namespace VPet_Simulator.Windows
             SmartMoveEventBox.IsChecked = mw.Set.SmartMove;
             PressLengthSlider.Value = mw.Set.PressLength / 1000.0;
             SwitchMsgOut.IsChecked = mw.Set.MessageBarOutside;
+            SwitchHideFromTaskControl.IsChecked = mw.Set.HideFromTaskControl;
 
             StartUpBox.IsChecked = mw.Set.StartUPBoot;
             StartUpSteamBox.IsChecked = mw.Set.StartUPBootSteam;
@@ -1305,6 +1306,14 @@ namespace VPet_Simulator.Windows
                 mw.LoadTalkDIY();
             BtnCGPTReSet.Content = "打开 {0} 设置".Translate(mw.TalkBoxCurr?.APIName ?? "Steam Workshop");
 
+        }
+
+        private void SwitchHideFromTaskControl_OnChecked(object sender, RoutedEventArgs e)
+        {
+            if (!AllowChange)
+                return;
+            mw.Set.HideFromTaskControl = SwitchHideFromTaskControl.IsChecked == true;
+            ButtonRestartGraph.Visibility = Visibility.Visible;
         }
     }
 }

--- a/VPet-Simulator.Windows/mod/0000_core/lang/en/Base2309.lps
+++ b/VPet-Simulator.Windows/mod/0000_core/lang/en/Base2309.lps
@@ -31,3 +31,6 @@ EXP#EXP:|
 按好感度#By favorability:|
 更好买老顾客大优惠!桌宠的食物钱我来出!\n更好买提示您:$10以下的食物/药品等随便赊账#Better buy old customers big discounts! I'll pay for the food money of the VPET!\nBetter buy tips you: $10 or less food / medicine, etc. can be charged at will:|
 看到您囊中羞涩,桌宠拿出了1000块私房钱出来给你#Seeing that you are shy in your pocket, the VPET took out 1000 yuan of private money to give you:|
+隐藏窗口#Hide Window:|
+在任务切换器中隐藏窗口#Hide window from task switcher:|
+在Alt+Tab中隐藏#Hide from Alt+Tab:|


### PR DESCRIPTION
Add `hide from taskswitcher` via `WS_EX_TOOLWINDOW`. 
Add an option in settings window to toggle `hide from taskswitcher. 
Add English translation for changes.

繁体中文翻译因为不熟悉繁中术语，目前没加上。

Close #210