### PR TITLE
构造时矩形约束 v3

### DIFF
--- a/VPet-Simulator.Windows/MainWindow.xaml.cs
+++ b/VPet-Simulator.Windows/MainWindow.xaml.cs
@@ -99,7 +99,7 @@ namespace VPet_Simulator.Windows
                 //this.Height = 450 * ZoomSlider.Value;
                 InitializeComponent();
 
-                //this.Height = 500 * Set.ZoomLevel;
+                this.Height = 500 * Set.ZoomLevel;
                 this.Width = 500 * Set.ZoomLevel;
 
                 double L = 0, T = 0;
@@ -118,16 +118,16 @@ namespace VPet_Simulator.Windows
                     L = point.X; T = point.Y;
                 }
 
-                //// control position inside bounds
-                Core.Controller = new MWController(this);
-                //double dist;
-                //if ((dist = Core.Controller.GetWindowsDistanceLeft()) < 0) L -= dist;
-                //if ((dist = Core.Controller.GetWindowsDistanceRight()) < 0) L += dist;
-                //if ((dist = Core.Controller.GetWindowsDistanceUp()) < 0) T -= dist;
-                //if ((dist = Core.Controller.GetWindowsDistanceDown()) < 0) T += dist;
-
                 Left = L;
                 Top = T;
+
+                // control position inside bounds
+                Core.Controller = new MWController(this);
+                double dist;
+                if ((dist = Core.Controller.GetWindowsDistanceLeft()) < 0) Left -= dist;
+                if ((dist = Core.Controller.GetWindowsDistanceRight()) < 0) Left += dist;
+                if ((dist = Core.Controller.GetWindowsDistanceUp()) < 0) Top -= dist;
+                if ((dist = Core.Controller.GetWindowsDistanceDown()) < 0) Top += dist;
 
                 if (Set.TopMost)
                 {


### PR DESCRIPTION
经试验，最快捷&代码量最少的去除错误高度的办法是把上面注释掉的那行高度设置给补回来