### PR TITLE
修复首次启动存档加载问题

### DIFF
--- a/VPet-Simulator.Windows/MainWindow.xaml.cs
+++ b/VPet-Simulator.Windows/MainWindow.xaml.cs
@@ -287,6 +287,12 @@ namespace VPet_Simulator.Windows
                         return i;
                     return 0;
                 }).ToList();
+                if(ds.Count == 0)
+                {
+                    GameSavesData = new GameSave_v2(petname.Translate());
+                    Core.Save = GameSavesData.GameSave;
+                    return;
+                }
                 int.TryParse(ds.Last().Split('_')[1].Split('.')[0], out int lastid);
                 if (Set.SaveTimes < lastid)
                 {
@@ -311,8 +317,11 @@ namespace VPet_Simulator.Windows
                 }
 
             }
-            GameSavesData = new GameSave_v2(petname.Translate());
-            Core.Save = GameSavesData.GameSave;
+            else
+            {
+                GameSavesData = new GameSave_v2(petname.Translate());
+                Core.Save = GameSavesData.GameSave;
+            }
         }
         public async void GameLoad()
         {


### PR DESCRIPTION
### 问题描述
新用户首次打开游戏时，可能会出现停在“尝试加载游戏存档”然后闪退的情况
这是由于Steam会在启动游戏时同步云存档并创建一个并没有存档的Saves文件夹
游戏在读取时默认只要有Saves文件夹就有存档，并尝试读取，然后就会崩溃
### 解决办法
非常简单，加个存档列表是否为空的判断就可以了（