### PR TITLE
错误修复及功能改进

### DIFF
--- a/VPet-Simulator.Windows/Function/CoreMOD.cs
+++ b/VPet-Simulator.Windows/Function/CoreMOD.cs
@@ -400,7 +400,7 @@ namespace VPet_Simulator.Windows
                             {
                                 if (loadfile[tmpfi.Name][(gbol)"ignoreError"])
                                     continue;
-                                ErrorMessage = e.Message;
+                                ErrorMessage = e.Message + "\n" + e.InnerException.Message ?? "";
                                 SuccessLoad = false;
                             }
                         }

--- a/VPet-Simulator.Windows/MainWindow.cs
+++ b/VPet-Simulator.Windows/MainWindow.cs
@@ -1904,7 +1904,7 @@ namespace VPet_Simulator.Windows
                   DisplayGrid.Child = Main;
                   Task.Run(async () =>
                   {
-                      while (Main.IsWorking)
+                      while (!Main.IsWorking)
                       {
                           Thread.Sleep(100);
                       }


### PR DESCRIPTION
修复加载MOD时，如果主线程长时间阻塞，导致加载完成后加载消息框无法消除的错误
使MOD加载异常信息显示更详细