### PR TITLE
修复收藏按钮显示bug

### DIFF
--- a/VPet-Simulator.Windows/WinDesign/winWorkMenu.xaml.cs
+++ b/VPet-Simulator.Windows/WinDesign/winWorkMenu.xaml.cs
@@ -244,6 +244,7 @@ public partial class winWorkMenu : WindowX
             {
                 btnStart.IsEnabled = false;
                 btnAddAuto.IsEnabled = false;
+                tbtn_star.IsChecked = false;
                 tbGain.Text = "??";
                 tbSpeed.Text = "??";
                 tbFood.Text = "??";


### PR DESCRIPTION
修复「从已收藏工作，切换到其他工作类型后，收藏按钮仍会保持亮起」的bug

修复前的情况：

https://github.com/user-attachments/assets/533c2e0a-d8a9-4c80-9659-4caed77973f4

