### PR TITLE
[BUG] 允许照片图库以翻译文本进行搜寻

### DIFF
--- a/VPet-Simulator.Windows/WinDesign/winGallery.xaml.cs
+++ b/VPet-Simulator.Windows/WinDesign/winGallery.xaml.cs
@@ -118,7 +118,8 @@ public partial class winGallery : WindowX
                     && (isIllustrationChecked || p.Type != Photo.PhotoType.Illustration)
                     && (isThumbnailChecked || p.Type != Photo.PhotoType.Thumbnail)
                     && (!selectedTags.Any() || selectedTags.All(st => p.TagsTrans.Contains(st)))
-                    && (string.IsNullOrWhiteSpace(searchText) || p.Name.Contains(searchText) || p.Description.Contains(searchText)));
+                    && (string.IsNullOrWhiteSpace(searchText) || p.Name.Contains(searchText) || p.Description.Contains(searchText)
+                        || p.TranslateName.Contains(searchText) || p.Description.Translate().Contains(searchText)));
             photos.AddRange(lockphoto);
         }
         //获取解锁的图片
@@ -129,7 +130,8 @@ public partial class winGallery : WindowX
                 && (isIllustrationChecked || p.Type != Photo.PhotoType.Illustration)
                 && (isThumbnailChecked || p.Type != Photo.PhotoType.Thumbnail)
                 && (!selectedTags.Any() || selectedTags.All(st => p.TagsTrans.Contains(st)))
-                && (string.IsNullOrWhiteSpace(searchText) || p.Name.Contains(searchText) || p.Description.Contains(searchText)));
+                && (string.IsNullOrWhiteSpace(searchText) || p.Name.Contains(searchText) || p.Description.Contains(searchText)
+                    || p.TranslateName.Contains(searchText) || p.Description.Translate().Contains(searchText)));
 
             photos.AddRange(unlockphoto);
         }


### PR DESCRIPTION
修复现在无法用翻译语言进行搜寻的BUG。
例如zh-Hant时，要搜寻「猫猫」才可以找到「貓貓」。而直接搜寻「貓貓」则没有结果。

### 目前情況演示：
![貓貓](https://github.com/user-attachments/assets/303b53a3-9404-462f-9727-267a23d55b1c)

![猫猫](https://github.com/user-attachments/assets/7d341a70-6e35-4e79-8813-e65dbb520446)
