### PR TITLE
修复工作列小图示选单的「勾选状态」不一致问题

### DIFF
--- a/VPet-Simulator.Windows/PetHelper.xaml.cs
+++ b/VPet-Simulator.Windows/PetHelper.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using LinePutScript.Localization.WPF;
 using Panuon.WPF.UI;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -112,6 +113,9 @@ namespace VPet_Simulator.Windows
         private void WindowX_MouseRightButtonDown(object sender, MouseButtonEventArgs e)
         {
             mw.Topmost = !mw.Topmost;
+            //同步托盘图标菜单中「置于顶层」选项的选中状态
+            (mw.notifyIcon.ContextMenuStrip.Items.Find("NotifyIcon_TopMost", false).First() as
+                System.Windows.Forms.ToolStripMenuItem).Checked = mw.Topmost;
 
             if (mw.Topmost == true && mw.HitThrough == true)
                 mw.SetTransparentHitThrough();


### PR DESCRIPTION
## 目前情况：
如果用「快速切换小图示」的右键，来切换「置于顶层」设定的话，工作列的选单中的「置于顶层」选中状态不会同步，会不一致。
| 「快速切換小圖示」範例 | 「工作列選單」範例 |
|--------------------|----------------|
| ![快速切換小圖示範例](https://github.com/user-attachments/assets/c3a20474-bff1-4c6b-a23d-b6216f61fe80) | ![工作列選單範例](https://github.com/user-attachments/assets/f0aa8a3d-fd79-4c8f-9f61-5a2f58af3042) |

---

## 修正后情况：
工作列的「置于顶层」选项始终与实际设定保持一致。
![啓用「置於頂層」的範例」](https://github.com/user-attachments/assets/b4f82814-ceae-46b0-824f-97e2f12dd518)
