### PR TITLE
让照片图库搜寻支援 case-insensitive matching （跟进 #489）

### DIFF
--- a/VPet-Simulator.Windows/WinDesign/winGallery.xaml.cs
+++ b/VPet-Simulator.Windows/WinDesign/winGallery.xaml.cs
@@ -113,26 +113,39 @@ public partial class winGallery : WindowX
         //获取锁定的图片
         if (isLockedChecked)
         {
-            var lockphoto = mw.Photos.FindAll(p => p.IsUnlock == false
-                    && (!isFavoriteChecked || p.IsStar)
-                    && (isIllustrationChecked || p.Type != Photo.PhotoType.Illustration)
-                    && (isThumbnailChecked || p.Type != Photo.PhotoType.Thumbnail)
-                    && (!selectedTags.Any() || selectedTags.All(st => p.TagsTrans.Contains(st)))
-                    && (string.IsNullOrWhiteSpace(searchText) || p.Name.Contains(searchText) || p.Description.Contains(searchText)
-                        || p.TranslateName.Contains(searchText) || p.Description.Translate().Contains(searchText)));
+            var lockphoto = mw.Photos.FindAll(p =>
+                p.IsUnlock == false
+                && (!isFavoriteChecked || p.IsStar)
+                && (isIllustrationChecked || p.Type != Photo.PhotoType.Illustration)
+                && (isThumbnailChecked || p.Type != Photo.PhotoType.Thumbnail)
+                && (!selectedTags.Any() || selectedTags.All(st => p.TagsTrans.Contains(st)))
+                && (
+                    string.IsNullOrWhiteSpace(searchText)
+                    || p.Name.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                    || p.Description.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                    || p.TranslateName.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                    || p.Description.Translate().Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                )
+            );
             photos.AddRange(lockphoto);
         }
         //获取解锁的图片
         if (isUnlockedChecked)
         {
-            var unlockphoto = mw.Photos.FindAll(p => p.IsUnlock == true
+            var unlockphoto = mw.Photos.FindAll(p =>
+                p.IsUnlock == true
                 && (!isFavoriteChecked || p.IsStar)
                 && (isIllustrationChecked || p.Type != Photo.PhotoType.Illustration)
                 && (isThumbnailChecked || p.Type != Photo.PhotoType.Thumbnail)
                 && (!selectedTags.Any() || selectedTags.All(st => p.TagsTrans.Contains(st)))
-                && (string.IsNullOrWhiteSpace(searchText) || p.Name.Contains(searchText) || p.Description.Contains(searchText)
-                    || p.TranslateName.Contains(searchText) || p.Description.Translate().Contains(searchText)));
-
+                && (
+                    string.IsNullOrWhiteSpace(searchText)
+                    || p.Name.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                    || p.Description.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                    || p.TranslateName.Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                    || p.Description.Translate().Contains(searchText, StringComparison.OrdinalIgnoreCase)
+                )
+            );
             photos.AddRange(unlockphoto);
         }
 


### PR DESCRIPTION
对 #489 PR 的改进：
- 使照片搜寻功能支持 **case-insensitive** 匹配。
- Refactor code formatting for readability.

---

#### 示例（界面语言：`zh-Hant`）

**照片原始名称**：`Steam大奖赛`\
**照片翻译名称**：`Steam大獎賽`

---

#### 修改前表现

| 搜索关键词   | 搜索成功？ |
| ------- | ----- |
| Steam大獎 | ✅     |
| Steam大奖 | ✅     |
| steam大獎 | ❌     |
| steam大奖 | ❌     |

---

#### 修改后表现

| 搜索关键词   | 搜索成功？ |
| ------- | ----- |
| Steam大獎 | ✅     |
| Steam大奖 | ✅     |
| steam大獎 | ✅     |
| steam大奖 | ✅     |
