### PR TITLE
[BUG] Fix display of special char for `en`

### DIFF
--- a/VPet-Simulator.Windows/mod/0000_core/lang/en/Base2306.lps
+++ b/VPet-Simulator.Windows/mod/0000_core/lang/en/Base2306.lps
@@ -240,7 +240,7 @@ text#Text Set:|
 虚拟桌宠模拟器#VPet-Simulator:|
 点击此处开关鼠标穿透\n右键开关置于顶层\n长按挪动位置\n可在设置中关闭#Click here toggle mouse HitThrough\nRight-click toggle place in TopMost\nPress and hold to move position\nCan be turned off in the settings:|
 操作教程#How-to Tutorials:|
-重置位置与状态#Reset Position & Status:|
+重置位置与状态#Reset Position && Status:|
 桌宠重置成功#Desktop pet reset successful:|
 上传至Steam#Upload to Steam:|
  (版本高)# (Version High):|


### PR DESCRIPTION
- '&' is a special char in `MenuItem`, which needs to be escaped to display properly.

---

# Before
<img width="210" height="216" alt="image" src="https://github.com/user-attachments/assets/daa7314f-0055-4f45-b0dd-b1962b380970" />

# After
<img width="211" height="211" alt="image" src="https://github.com/user-attachments/assets/023038fb-d514-4763-b405-c48cb4453497" />
